### PR TITLE
Increase supported FAST version range and move to peer deps

### DIFF
--- a/change/@ni-fast-react-wrapper-fb009125-cd17-4815-9e1c-7175f5befb57.json
+++ b/change/@ni-fast-react-wrapper-fb009125-cd17-4815-9e1c-7175f5befb57.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Increase react supported version range and make all fast deps peerDependencies",
+  "packageName": "@ni/fast-react-wrapper",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11525,10 +11525,6 @@
       "name": "@ni/fast-react-wrapper",
       "version": "10.0.2",
       "license": "MIT",
-      "dependencies": {
-        "@ni/fast-element": "^10.0.2",
-        "@ni/fast-foundation": "^10.0.2"
-      },
       "devDependencies": {
         "@microsoft/api-extractor": "7.49.1",
         "@rollup/plugin-commonjs": "^28.0.0",
@@ -11570,7 +11566,9 @@
         "webpack": "^5.97.1"
       },
       "peerDependencies": {
-        "react": "^18"
+        "@ni/fast-element": "^10.0.2",
+        "@ni/fast-foundation": "^10.0.2",
+        "react": "^16 || ^17 || ^18"
       }
     },
     "packages/utilities/fast-web-utilities": {

--- a/packages/utilities/fast-react-wrapper/package.json
+++ b/packages/utilities/fast-react-wrapper/package.json
@@ -85,11 +85,9 @@
     "typescript": "~5.4.5",
     "webpack": "^5.97.1"
   },
-  "dependencies": {
-    "@ni/fast-element": "^10.0.2",
-    "@ni/fast-foundation": "^10.0.2"
-  },
   "peerDependencies": {
-    "react": "^18"
+    "@ni/fast-element": "^10.0.2",
+    "@ni/fast-foundation": "^10.0.2",
+    "react": "^16 || ^17 || ^18"
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

When forked the [original package react version range](https://github.com/microsoft/fast/blob/fd9068b94e4aa8d2282f0cce613f58436fae955d/packages/utilities/fast-react-wrapper/package.json#L94) was modified from `>=16.9.0` to just `^18` as that is what we used and we had not tested against the major changes in React `^19` around custom element integration.

## 📑 Test Plan

The upper bound of support range (`^18`) is unchanged and tested in repo. Admittedly, the existing tests report [deprecation warnings about React 18 compatibility](https://github.com/ni/fast/actions/runs/15230470071/job/42837711816#step:11:2525) but that is unchanged.
The down expanded version range (`^16 || ^17`) is not explicitly tested. Relying optimistically on previous compatibility prior to fork.
The move to peer dependencies should only prevent issues (multiple copies of fast-element / fast-foundation being imported). No specific testing added.

## ⏭ Next Steps

No follow-up actions required downstream.