### PR TITLE
Abstract NumberField's input filtering and value syncing to enable localization

### DIFF
--- a/change/@ni-fast-foundation-aaf179df-4628-4740-83f5-b671b69f975b.json
+++ b/change/@ni-fast-foundation-aaf179df-4628-4740-83f5-b671b69f975b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Abstract NumberField input filtering and value synchronization",
+  "packageName": "@ni/fast-foundation",
+  "email": "mert.akinc@emerson.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -224,7 +224,7 @@ export class NumberField extends FormAssociatedNumberField {
         }
 
         if (this.control && !this.isUserInput) {
-            this.control.value = this.value;
+            this.syncValueToInnerControl();
         }
 
         super.valueChanged(previous, this.value);
@@ -309,7 +309,7 @@ export class NumberField extends FormAssociatedNumberField {
 
         this.proxy.setAttribute("type", "number");
         this.validate();
-        this.control.value = this.value;
+        this.syncValueToInnerControl();
 
         if (this.autofocus) {
             DOM.queueUpdate(() => {
@@ -340,9 +340,9 @@ export class NumberField extends FormAssociatedNumberField {
      * @internal
      */
     public handleTextInput(): void {
-        this.control.value = this.control.value.replace(/[^0-9\-+e.]/g, "");
+        this.control.value = this.sanitizeInput(this.control.value);
         this.isUserInput = true;
-        this.value = this.control.value;
+        this.syncValueFromInnerControl();
     }
 
     /**
@@ -384,6 +384,29 @@ export class NumberField extends FormAssociatedNumberField {
      * @internal
      */
     public handleBlur(): void {
+        this.syncValueToInnerControl();
+    }
+
+    /**
+     * Sanitizes the text input by the user.
+     * @param inputText The user-input text to sanitize
+     * @returns The sanitized text, containing only valid characters for a number field
+     */
+    protected sanitizeInput(inputText: string): string {
+        return inputText.replace(/[^0-9\-+e.]/g, "");
+    }
+
+    /**
+     * Synchronizes the value from the input control in the shadow DOM to the host component.
+     */
+    protected syncValueFromInnerControl(): void {
+        this.value = this.control.value;
+    }
+
+    /**
+     * Synchronizes the value from the host component to the input control in the shadow DOM.
+     */
+    protected syncValueToInnerControl(): void {
         this.control.value = this.value;
     }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

To support locale-dependent decimal separators in the `NumberField` (in derived implementations), this change abstracts the filtering performed on the user-input text and the synchronization of the host component's value with the value displayed to the user (i.e. the `value` from the shadow DOM `input` element).

### 🎫 Issues

None

## 👩‍💻 Reviewer Notes

None

## 📑 Test Plan

Existing automated tests suffice.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
