### PR TITLE
feat: increase Number Field precision to 15

### DIFF
--- a/change/@ni-fast-foundation-b5e796b8-1c7d-4f8d-98d6-16123cc91637.json
+++ b/change/@ni-fast-foundation-b5e796b8-1c7d-4f8d-98d6-16123cc91637.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "increase number field precision to 15",
+  "packageName": "@ni/fast-foundation",
+  "email": "hari.ram.karthik@emerson.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -870,7 +870,7 @@ describe("NumberField", () => {
             await disconnect();
         });
 
-        it("should allow number entry upto 15 digits", async () => {
+        it("should allow number entry up to 15 digits", async () => {
             const value = "123456789012345";
             const { element, disconnect } = await setup();
 
@@ -949,7 +949,7 @@ describe("NumberField", () => {
             await disconnect();
         });
 
-        it('should allow reading value as number upto 15 digits', async () => {
+        it("should allow reading value as number up to 15 digits", async () => {
             const { element, disconnect } = await setup();
 
             element.value = "123456789012345";
@@ -959,7 +959,7 @@ describe("NumberField", () => {
             await disconnect();
         });
 
-        it('should allow reading value as flot number upto 15 digits', async () => {
+        it("should allow reading value as number up to 15 fractional digits", async () => {
             const { element, disconnect } = await setup();
 
             element.value = "0.123456789012345";
@@ -979,7 +979,7 @@ describe("NumberField", () => {
             await disconnect();
         });
 
-        it("should round off value as float number to 15 digits", async () => {
+        it("should round off value as number to 15 fractional digits", async () => {
             const { element, disconnect } = await setup();
 
             element.value = "0.1234567890123456";

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -848,6 +848,27 @@ describe("NumberField", () => {
 
             await disconnect();
         });
+
+        it("should allow 15 precision float entry", async () => {
+            const { element, disconnect } = await setup();
+            const floatValue = "0.123456789012345";
+
+            element.setAttribute("value", floatValue);
+            expect(element.value).to.equal(floatValue);
+
+            await disconnect();
+        });
+
+        it("should round off float values to 15 precision", async () => {
+            const { element, disconnect } = await setup();
+            const floatValue = "0.1234567890123456";
+            const expectedValue = "0.123456789012346";
+
+            element.setAttribute("value", floatValue);
+            expect(element.value).to.equal(expectedValue);
+
+            await disconnect();
+        });
     });
 
     describe("hide step", () => {

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -849,7 +849,7 @@ describe("NumberField", () => {
             await disconnect();
         });
 
-        it("should allow 15 precision float entry", async () => {
+        it("should allow 15 digits float entry", async () => {
             const { element, disconnect } = await setup();
             const floatValue = "0.123456789012345";
 
@@ -865,6 +865,29 @@ describe("NumberField", () => {
             const expectedValue = "0.123456789012346";
 
             element.setAttribute("value", floatValue);
+            expect(element.value).to.equal(expectedValue);
+
+            await disconnect();
+        });
+
+        it("should allow number entry upto 15 digits", async () => {
+            const value = "123456789012345";
+            const { element, disconnect } = await setup();
+
+            element.setAttribute("value", value);
+
+            expect(element.value).to.equal(value);
+
+            await disconnect();
+        });
+
+        it("should round off number entry to 15 digits", async () => {
+            const value = "12345678901234567";
+            const expectedValue = "12345678901234600";
+            const { element, disconnect } = await setup();
+
+            element.setAttribute("value", value);
+
             expect(element.value).to.equal(expectedValue);
 
             await disconnect();

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -948,5 +948,45 @@ describe("NumberField", () => {
 
             await disconnect();
         });
+
+        it('should allow reading value as number upto 15 digits', async () => {
+            const { element, disconnect } = await setup();
+
+            element.value = "123456789012345";
+
+            expect(element.valueAsNumber).to.equal(123456789012345);
+
+            await disconnect();
+        });
+
+        it('should allow reading value as flot number upto 15 digits', async () => {
+            const { element, disconnect } = await setup();
+
+            element.value = "0.123456789012345";
+
+            expect(element.valueAsNumber).to.equal(0.123456789012345);
+
+            await disconnect();
+        });
+
+        it("should round off value as number to 15 digits", async () => {
+            const { element, disconnect } = await setup();
+
+            element.value = "12345678901234567";
+
+            expect(element.valueAsNumber).to.equal(12345678901234600);
+
+            await disconnect();
+        });
+
+        it("should round off value as float number to 15 digits", async () => {
+            const { element, disconnect } = await setup();
+
+            element.value = "0.1234567890123456";
+
+            expect(element.valueAsNumber).to.equal(0.123456789012346);
+
+            await disconnect();
+        });
     });
 });

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -249,7 +249,7 @@ export class NumberField extends FormAssociatedNumberField {
      * @internal
      */
     private getValidValue(value: string): string {
-        let validValue: number | string = parseFloat(parseFloat(value).toPrecision(12));
+        let validValue: number | string = parseFloat(parseFloat(value).toPrecision(15));
         if (isNaN(validValue)) {
             validValue = "";
         } else {


### PR DESCRIPTION
# Pull Request

## 📖 Description
To fix [GitHub issue](https://github.com/ni/nimble/issues/2633)

## 👩‍💻 Reviewer Notes

Increased precision to 15

## 📑 Test Plan

- Unit test added
- Existing unit tests passed
- Manually verified that when the user tries to increment a value starting from 0.2 with a step of 0.1, the result is exactly 0.3, which was 0.30000000000000004 when removing `toPrecision()` completely.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->