### PR TITLE
[Number-field] Limit precision of value when clamping to min/max

### DIFF
--- a/change/@ni-fast-foundation-069a6dff-f9f8-4a21-9a03-f3789a3d2876.json
+++ b/change/@ni-fast-foundation-069a6dff-f9f8-4a21-9a03-f3789a3d2876.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Number field limit precision when clamping to min/max",
+  "packageName": "@ni/fast-foundation",
+  "email": "mert.akinc@emerson.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-fast-foundation-069a6dff-f9f8-4a21-9a03-f3789a3d2876.json
+++ b/change/@ni-fast-foundation-069a6dff-f9f8-4a21-9a03-f3789a3d2876.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Number field limit precision when clamping to min/max",
   "packageName": "@ni/fast-foundation",
-  "email": "mert.akinc@emerson.com",
+  "email": "7282195+m-akinc@users.noreply.github.com",
   "dependentChangeType": "patch"
 }

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -527,7 +527,7 @@ describe("NumberField", () => {
 
         it("should set max value", async () => {
             const max = 10;
-            const { element, connect, disconnect } = await setup({max});
+            const { element, disconnect } = await setup({max});
 
             expect(
                 element.shadowRoot?.querySelector(".control")?.getAttribute("max")
@@ -542,6 +542,16 @@ describe("NumberField", () => {
             const { element, disconnect } = await setup({value, max});
 
             expect(element.value).to.equal(max.toString());
+
+            await disconnect();
+        });
+
+        it("should limit precision when clamping to max", async () => {
+            const max = 1000.0123456789; // 14 digits of precision
+            const value = '1001';
+            const { element, disconnect } = await setup({value, max});
+
+            expect(element.value).to.equal("1000.0123468");
 
             await disconnect();
         });
@@ -572,6 +582,16 @@ describe("NumberField", () => {
             await DOM.nextUpdate();
 
             expect(element.value).to.equal(min.toString());
+            await disconnect();
+        });
+
+        it("should limit precision when clamping to min", async () => {
+            const min = 1000.0123456789; // 14 digits of precision
+            const value = '999';
+            const { element, disconnect } = await setup({value, min});
+
+            expect(element.value).to.equal("1000.01234678");
+
             await disconnect();
         });
 

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -551,7 +551,7 @@ describe("NumberField", () => {
             const value = '1000001';
             const { element, disconnect } = await setup({value, max});
 
-            expect(element.value).to.equal("1000000.0123468");
+            expect(element.value).to.equal("1000000.01234568");
 
             await disconnect();
         });
@@ -590,7 +590,7 @@ describe("NumberField", () => {
             const value = '999999';
             const { element, disconnect } = await setup({value, min});
 
-            expect(element.value).to.equal("1000000.01234678");
+            expect(element.value).to.equal("1000000.01234568");
 
             await disconnect();
         });

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -547,11 +547,11 @@ describe("NumberField", () => {
         });
 
         it("should limit precision when clamping to max", async () => {
-            const max = 1000.0123456789; // 14 digits of precision
-            const value = '1001';
+            const max = 1000000.0123456789; // 17 digits of precision
+            const value = '1000001';
             const { element, disconnect } = await setup({value, max});
 
-            expect(element.value).to.equal("1000.0123468");
+            expect(element.value).to.equal("1000000.0123468");
 
             await disconnect();
         });
@@ -586,11 +586,11 @@ describe("NumberField", () => {
         });
 
         it("should limit precision when clamping to min", async () => {
-            const min = 1000.0123456789; // 14 digits of precision
-            const value = '999';
+            const min = 1000000.0123456789; // 17 digits of precision
+            const value = '999999';
             const { element, disconnect } = await setup({value, min});
 
-            expect(element.value).to.equal("1000.01234678");
+            expect(element.value).to.equal("1000000.01234678");
 
             await disconnect();
         });

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -242,6 +242,10 @@ export class NumberField extends FormAssociatedNumberField {
         super.validate(this.control);
     }
 
+    private limitPrecision(value: number): number {
+        return parseFloat(value.toPrecision(12));
+    }
+
     /**
      * Sets the internal value to a valid number between the min and max properties
      * @param value - user input
@@ -249,15 +253,19 @@ export class NumberField extends FormAssociatedNumberField {
      * @internal
      */
     private getValidValue(value: string): string {
-        let validValue: number | string = parseFloat(parseFloat(value).toPrecision(12));
+        let validValue: number | string = this.limitPrecision(parseFloat(value));
         if (isNaN(validValue)) {
             validValue = "";
         } else {
-            validValue = Math.min(validValue, this.max ?? validValue);
-            validValue = Math.max(validValue, this.min ?? validValue).toString();
+            if (this.max !== undefined) {
+                validValue = Math.min(validValue, this.limitPrecision(this.max));
+            }
+            if (this.min !== undefined) {
+                validValue = Math.max(validValue, this.limitPrecision(this.min));
+            }
         }
 
-        return validValue;
+        return validValue.toString();
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -255,14 +255,13 @@ export class NumberField extends FormAssociatedNumberField {
     private getValidValue(value: string): string {
         let validValue: number | string = this.limitPrecision(parseFloat(value));
         if (isNaN(validValue)) {
-            validValue = "";
-        } else {
-            if (this.max !== undefined) {
-                validValue = Math.min(validValue, this.limitPrecision(this.max));
-            }
-            if (this.min !== undefined) {
-                validValue = Math.max(validValue, this.limitPrecision(this.min));
-            }
+            return "";
+        }
+        if (this.max !== undefined) {
+            validValue = Math.min(validValue, this.limitPrecision(this.max));
+        }
+        if (this.min !== undefined) {
+            validValue = Math.max(validValue, this.limitPrecision(this.min));
         }
 
         return validValue.toString();

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -253,7 +253,7 @@ export class NumberField extends FormAssociatedNumberField {
      * @internal
      */
     private getValidValue(value: string): string {
-        let validValue: number | string = this.limitPrecision(parseFloat(value));
+        let validValue: number = this.limitPrecision(parseFloat(value));
         if (isNaN(validValue)) {
             return "";
         }


### PR DESCRIPTION
# Pull Request

## 📖 Description

See https://github.com/ni/nimble/issues/2657

The number-field's value is limited to 12 digits of precision, except when it is clamped/coerced to the min or max, and the min or max has more than 12 digits of precision. We consistently limit the precision of the value.

We could just limit the precision of the min and max when set, but it seems better to allow the min/max to remain exactly as the user specified. Instead, we can just apply the precision limit to the value after clamping it to the min or max.

## 👩‍💻 Reviewer Notes

Because `toPrecision()` rounds rather than truncates, my implementation may actually result in values that fall (very slightly) outside the user-specified min or max. I did not find a built-in function that avoids this, and custom logic to correct for unwanted rounding is a little verbose/complex to do in a way that avoids floating point representation inaccuracies. I think it is worth the slight boundary violation to keep the code simple.

## 📑 Test Plan

Added two new unit tests.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
