### PR TITLE
Fix FAST lint warnings

### DIFF
--- a/change/@ni-fast-element-a1b73b56-6a75-4ff0-88d8-c60e3e0edace.json
+++ b/change/@ni-fast-element-a1b73b56-6a75-4ff0-88d8-c60e3e0edace.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix lint warnings",
+  "packageName": "@ni/fast-element",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-fast-foundation-419a509e-ab58-4731-894e-8e7316020bdf.json
+++ b/change/@ni-fast-foundation-419a509e-ab58-4731-894e-8e7316020bdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix lint warnings",
+  "packageName": "@ni/fast-foundation",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-fast-web-utilities-e8e91036-5c2a-49bb-a426-96e7304514ed.json
+++ b/change/@ni-fast-web-utilities-e8e91036-5c2a-49bb-a426-96e7304514ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix lint warnings",
+  "packageName": "@ni/fast-web-utilities",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/fast-web-utilities/src/dom.ts
+++ b/packages/utilities/fast-web-utilities/src/dom.ts
@@ -76,7 +76,7 @@ export function canUseFocusVisible(): boolean {
     try {
         (styleElement.sheet as any).insertRule("foo:focus-visible {color:inherit}", 0);
         _canUseFocusVisible = true;
-    } catch (e) {
+    } catch {
         _canUseFocusVisible = false;
     } finally {
         document.head.removeChild(styleElement);

--- a/packages/web-components/fast-element/src/components/controller.ts
+++ b/packages/web-components/fast-element/src/components/controller.ts
@@ -258,9 +258,13 @@ export class Controller extends PropertyChangeNotifier {
             if (targetBehaviors.has(behavior)) {
                 const count = targetBehaviors.get(behavior)! - 1;
 
-                count === 0 || force
-                    ? targetBehaviors.delete(behavior) && behaviorsToUnbind.push(behavior)
-                    : targetBehaviors.set(behavior, count);
+                if (count === 0 || force) {
+                    if(targetBehaviors.delete(behavior)) {
+                        behaviorsToUnbind.push(behavior);
+                    }
+                } else {
+                    targetBehaviors.set(behavior, count);
+                }
             }
         }
 

--- a/packages/web-components/fast-element/src/dom.ts
+++ b/packages/web-components/fast-element/src/dom.ts
@@ -220,9 +220,11 @@ export const DOM = Object.freeze({
      * If the value is true, the attribute is added; otherwise it is removed.
      */
     setBooleanAttribute(element: HTMLElement, attributeName: string, value: boolean) {
-        value
-            ? element.setAttribute(attributeName, "")
-            : element.removeAttribute(attributeName);
+        if (value) {
+            element.setAttribute(attributeName, "");
+        } else {
+            element.removeAttribute(attributeName);
+        }
     },
 
     /**

--- a/packages/web-components/fast-element/src/styles/element-styles.ts
+++ b/packages/web-components/fast-element/src/styles/element-styles.ts
@@ -191,7 +191,7 @@ if (DOM.supportsAdoptedStyleSheets) {
                 }
             }
         };
-    } catch (e) {
+    } catch {
         // Do nothing if an error is thrown, the default
         // case handles FrozenArray.
     }

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -96,9 +96,7 @@ export class Accordion extends FoundationElement {
             if (item instanceof AccordionItem) {
                 item.addEventListener("change", this.activeItemChange);
                 if (this.isSingleExpandMode()) {
-                    this.activeItemIndex !== index
-                        ? (item.expanded = false)
-                        : (item.expanded = true);
+                    item.expanded = this.activeItemIndex === index
                 }
             }
             const itemId: string | null = this.accordionIds[index];

--- a/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.ts
@@ -68,13 +68,17 @@ export class Breadcrumb extends FoundationElement {
             item.hasAttribute("href") &&
             item instanceof BreadcrumbItem
         ) {
-            isLastNode
-                ? (item as BreadcrumbItem).setAttribute("aria-current", "page")
-                : (item as BreadcrumbItem).removeAttribute("aria-current");
+            if (isLastNode) {
+                (item as BreadcrumbItem).setAttribute("aria-current", "page");
+            } else {
+                (item as BreadcrumbItem).removeAttribute("aria-current");
+            }
         } else if (childNodeWithHref !== null) {
-            isLastNode
-                ? childNodeWithHref.setAttribute("aria-current", "page")
-                : childNodeWithHref.removeAttribute("aria-current");
+            if (isLastNode) {
+                childNodeWithHref.setAttribute("aria-current", "page");
+            } else {
+                childNodeWithHref.removeAttribute("aria-current");
+            }
         }
     }
 }

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -139,10 +139,10 @@ export class Button extends FormAssociatedButton {
             this.proxy.type = this.type;
         }
 
-        next === "submit" && this.addEventListener("click", this.handleSubmission);
-        previous === "submit" && this.removeEventListener("click", this.handleSubmission);
-        next === "reset" && this.addEventListener("click", this.handleFormReset);
-        previous === "reset" && this.removeEventListener("click", this.handleFormReset);
+        if (next === "submit") this.addEventListener("click", this.handleSubmission);
+        if (previous === "submit") this.removeEventListener("click", this.handleSubmission);
+        if (next === "reset") this.addEventListener("click", this.handleFormReset);
+        if (previous === "reset") this.removeEventListener("click", this.handleFormReset);
     }
 
     /**
@@ -217,9 +217,11 @@ export class Button extends FormAssociatedButton {
 
         // Browser support for requestSubmit is not comprehensive
         // so click the proxy if it isn't supported
-        typeof this.form.requestSubmit === "function"
-            ? this.form.requestSubmit(this.proxy)
-            : this.proxy.click();
+        if (typeof this.form.requestSubmit === "function") {
+            this.form.requestSubmit(this.proxy);
+        } else {
+            this.proxy.click();
+        }
 
         if (!attached) {
             this.detachProxy();

--- a/packages/web-components/fast-foundation/src/calendar/calendar.ts
+++ b/packages/web-components/fast-foundation/src/calendar/calendar.ts
@@ -340,7 +340,7 @@ export class Calendar extends FoundationElement {
      * @public
      */
     public handleDateSelect(event: Event, day: CalendarDateInfo): void {
-        event.preventDefault;
+        event.preventDefault();
         this.$emit("dateselected", day);
     }
 

--- a/packages/web-components/fast-foundation/src/di/di.ts
+++ b/packages/web-components/fast-foundation/src/di/di.ts
@@ -1074,11 +1074,9 @@ export function transient<T extends Constructable>(
 type SingletonOptions = { scoped: boolean };
 const defaultSingletonOptions = { scoped: false };
 
-function singletonDecorator<T extends Constructable>(
+type SingletonDecoratorType = <T extends Constructable>(
     target: T & Partial<RegisterSelf<T>>
-): T & RegisterSelf<T> {
-    return DI.singleton(target);
-}
+) => T & RegisterSelf<T>;
 
 /**
  * Registers the decorated class as a singleton dependency; the class will only be created once. Each
@@ -1093,7 +1091,7 @@ function singletonDecorator<T extends Constructable>(
  * @public
  */
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-export function singleton<T extends Constructable>(): typeof singletonDecorator;
+export function singleton<T extends Constructable>(): SingletonDecoratorType;
 
 /**
  * @public
@@ -1101,7 +1099,7 @@ export function singleton<T extends Constructable>(): typeof singletonDecorator;
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 export function singleton<T extends Constructable>(
     options?: SingletonOptions
-): typeof singletonDecorator;
+): SingletonDecoratorType;
 
 /**
  * Registers the `target` class as a singleton dependency; the class will only be created once. Each
@@ -1126,7 +1124,7 @@ export function singleton<T extends Constructable>(
  */
 export function singleton<T extends Constructable>(
     targetOrOptions?: (T & Partial<RegisterSelf<T>>) | SingletonOptions
-): (T & RegisterSelf<T>) | typeof singletonDecorator {
+): (T & RegisterSelf<T>) | SingletonDecoratorType {
     if (typeof targetOrOptions === "function") {
         return DI.singleton(targetOrOptions);
     }

--- a/packages/web-components/fast-foundation/src/switch/switch.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.ts
@@ -41,9 +41,11 @@ export class Switch extends FormAssociatedSwitch {
             this.proxy.readOnly = this.readOnly;
         }
 
-        this.readOnly
-            ? this.classList.add("readonly")
-            : this.classList.remove("readonly");
+        if (this.readOnly) {
+            this.classList.add("readonly");
+        } else {
+            this.classList.remove("readonly");
+        }
     }
 
     /**
@@ -99,6 +101,10 @@ export class Switch extends FormAssociatedSwitch {
         /**
          * @deprecated - this behavior already exists in the template and should not exist in the class.
          */
-        this.checked ? this.classList.add("checked") : this.classList.remove("checked");
+        if (this.checked) {
+            this.classList.add("checked");
+         } else {
+            this.classList.remove("checked");
+         }
     }
 }

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -237,9 +237,11 @@ export class Tabs extends FoundationElement {
             tab.style[gridHorizontalProperty] = "";
             tab.style[gridVerticalProperty] = "";
             tab.style[gridProperty] = `${index + 1}`;
-            !this.isHorizontal()
-                ? tab.classList.add("vertical")
-                : tab.classList.remove("vertical");
+            if (!this.isHorizontal()) {
+                tab.classList.add("vertical");
+            } else {
+                tab.classList.remove("vertical");
+            }
         });
     };
 
@@ -249,9 +251,11 @@ export class Tabs extends FoundationElement {
             const tabpanelId: string = this.tabpanelIds[index];
             tabpanel.setAttribute("id", tabpanelId);
             tabpanel.setAttribute("aria-labelledby", tabId);
-            this.activeTabIndex !== index
-                ? tabpanel.setAttribute("hidden", "")
-                : tabpanel.removeAttribute("hidden");
+            if (this.activeTabIndex !== index) {
+                tabpanel.setAttribute("hidden", "");
+            } else {
+                tabpanel.removeAttribute("hidden");
+            }
         });
     };
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

When you create a PR in this repo, GitHub displays a bunch of lint warnings for files that aren't part of the PR. I would like to get rid of this noise. For example: https://github.com/ni/fast/pull/19/files 

### 🎫 Issues

None

## 👩‍💻 Reviewer Notes

I manually fixed several warnings. Most of them were unused variables or conditional statements with side effects. There was only one functional change, which I'll call out in a comment.

## 📑 Test Plan

Relying on pipeline

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->