### PR TITLE
Run custom elements manifest generation in build for fast foundation

### DIFF
--- a/change/@ni-fast-foundation-bce0bc65-f302-492c-a640-8e7375f2192b.json
+++ b/change/@ni-fast-foundation-bce0bc65-f302-492c-a640-8e7375f2192b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Actually include custom-elements.json in build",
+  "packageName": "@ni/fast-foundation",
+  "email": "1588923+rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/custom-elements-manifest.config.mjs
+++ b/packages/web-components/fast-foundation/custom-elements-manifest.config.mjs
@@ -5,12 +5,12 @@ export default {
     "src/**/*.ts"
   ],
   exclude: [
-    "**/__test__/",
-    "**/design-system/",
-    "**/design-token/",
-    "**/di/",
-    "**/utilities/",
-    "**/test-utilities/",
+    "**/__test__/**",
+    "**/design-system/**",
+    "**/design-token/**",
+    "**/di/**",
+    "**/utilities/**",
+    "**/test-utilities/**",
     "**/*.spec.ts",
     "**/*.template.ts",
     "**/index.ts",

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -21,7 +21,7 @@
   "types": "dist/fast-foundation.d.ts",
   "unpkg": "dist/fast-foundation.min.js",
   "scripts": {
-    "build": "npm run clean:dist && npm run build:tsc && npm run build:rollup && npm run doc",
+    "build": "npm run clean:dist && npm run build:tsc && npm run build:rollup && npm run doc && npm run build:cem",
     "pack": "npm pack",
     "lint": "npm run eslint",
     "format": "npm run eslint:fix",


### PR DESCRIPTION
# Pull Request

## 📖 Description

In https://github.com/ni/fast/pull/36 scripts to build a custom elements manifest wree added but not included in the build step. This PR adds that step to build

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
