### PR TITLE
Update disposeContiguousBatch implementation to work around range deleteContents bug in Firefox

### DIFF
--- a/change/@ni-fast-element-97e45dcd-0443-4afe-a6d1-5a326b801fdc.json
+++ b/change/@ni-fast-element-97e45dcd-0443-4afe-a6d1-5a326b801fdc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update `disposeContiguousBatch` implementation to work around range `deleteContents` bug in Firefox",
+  "packageName": "@ni/fast-element",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/templating/view.spec.ts
+++ b/packages/web-components/fast-element/src/templating/view.spec.ts
@@ -1,41 +1,42 @@
-import { expect } from "chai";
-import type { Behavior } from "../observation/behavior";
-import { HTMLView } from "./view";
+import chai, { expect } from "chai";
 import spies from "chai-spies";
+import { HTMLView } from "./view";
 
 chai.use(spies);
 
 describe("The HTMLView", () => {
-    function createFragment(...nodes: Node[]): DocumentFragment {
-        const fragment = document.createDocumentFragment();
-        for (const node of nodes) {
-            fragment.appendChild(node);
-        }
-        return fragment;
-    }
+	describe("disposeContiguousBatch", () => {
+		function createViewWithDisposeSpy(onDispose: () => void) {
+			const fragment = document.createDocumentFragment();
+			fragment.appendChild(document.createComment("start"));
+			fragment.appendChild(document.createComment("end"));
 
-    function createView(
-        nodes: Node[],
-        behaviors: Behavior[] = []
-    ): HTMLView {
-        return new HTMLView(createFragment(...nodes), behaviors);
-    }
+			const view = new HTMLView(fragment, []);
+			const disposeSpy = chai.spy(onDispose);
+			chai.spy.on(view, "dispose", disposeSpy);
 
-    it('disposeContiguousBatch disposes all views', () => {
-        const viewCount = 10;
-        const views: HTMLView[] = [];
-        const disposeSpies: ChaiSpies.Spy[] = [];
-        for (let i = 0; i < viewCount; i++) {
-            const span = document.createElement("span");
-            const view = createView([span]);
-            views.push(view);
-            disposeSpies.push(chai.spy.on(view, "dispose"));
-        }
+			return { view, disposeSpy };
+		}
 
-        HTMLView.disposeContiguousBatch(views);
+		it("returns without throwing when given an empty batch", () => {
+			expect(() => HTMLView.disposeContiguousBatch([])).not.to.throw();
+		});
 
-        for (const spy of disposeSpies) {
-            expect(spy).to.have.been.called.exactly(1);
-        }
-    });
+		it("disposes each view in the provided batch", () => {
+			const view1 = createViewWithDisposeSpy(() => {});
+			const view2 = createViewWithDisposeSpy(() => {});
+			const view3 = createViewWithDisposeSpy(() => {});
+			const views = [
+				view1.view,
+				view2.view,
+				view3.view,
+			];
+
+			HTMLView.disposeContiguousBatch(views);
+
+			expect(view1.disposeSpy).to.have.been.called.once;
+			expect(view2.disposeSpy).to.have.been.called.once;
+			expect(view3.disposeSpy).to.have.been.called.once;
+		});
+	});
 });

--- a/packages/web-components/fast-element/src/templating/view.spec.ts
+++ b/packages/web-components/fast-element/src/templating/view.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import type { Behavior } from "../observation/behavior";
+import { HTMLView } from "./view";
+import spies from "chai-spies";
+
+chai.use(spies);
+
+describe("The HTMLView", () => {
+    function createFragment(...nodes: Node[]): DocumentFragment {
+        const fragment = document.createDocumentFragment();
+        for (const node of nodes) {
+            fragment.appendChild(node);
+        }
+        return fragment;
+    }
+
+    function createView(
+        nodes: Node[],
+        behaviors: Behavior[] = []
+    ): HTMLView {
+        return new HTMLView(createFragment(...nodes), behaviors);
+    }
+
+    it('disposeContiguousBatch disposes all views', () => {
+        const viewCount = 10;
+        const views: HTMLView[] = [];
+        const disposeSpies: ChaiSpies.Spy[] = [];
+        for (let i = 0; i < viewCount; i++) {
+            const span = document.createElement("span");
+            const view = createView([span]);
+            views.push(view);
+            disposeSpies.push(chai.spy.on(view, "dispose"));
+        }
+
+        HTMLView.disposeContiguousBatch(views);
+
+        for (const spy of disposeSpies) {
+            expect(spy).to.have.been.called.exactly(1);
+        }
+    });
+});

--- a/packages/web-components/fast-element/src/templating/view.ts
+++ b/packages/web-components/fast-element/src/templating/view.ts
@@ -251,7 +251,7 @@ export class HTMLView implements ElementView, SyntheticView {
     }
 
     /**
-     * Efficiently disposes of a contiguous range of synthetic view instances.
+     * Disposes of a contiguous range of synthetic view instances.
      * @param views - A contiguous range of views to be disposed.
      */
     public static disposeContiguousBatch(views: SyntheticView[]): void {
@@ -259,18 +259,9 @@ export class HTMLView implements ElementView, SyntheticView {
             return;
         }
 
-        range.setStartBefore(views[0].firstChild);
-        range.setEndAfter(views[views.length - 1].lastChild);
-        range.deleteContents();
-
         for (let i = 0, ii = views.length; i < ii; ++i) {
-            const view = views[i] as any;
-            const behaviors = view.behaviors as Behavior[];
-            const oldSource = view.source;
-
-            for (let j = 0, jj = behaviors.length; j < jj; ++j) {
-                behaviors[j].unbind(oldSource);
-            }
+            const view = views[i];
+            view.dispose();
         }
     }
 }

--- a/packages/web-components/fast-element/src/templating/view.ts
+++ b/packages/web-components/fast-element/src/templating/view.ts
@@ -81,10 +81,6 @@ export interface SyntheticView extends View {
     dispose(): void;
 }
 
-// A singleton Range instance used to efficiently remove ranges of DOM nodes.
-// See the implementation of HTMLView below for further details.
-const range = document.createRange();
-
 /**
  * The standard View implementation, which also implements ElementView and SyntheticView.
  * @public


### PR DESCRIPTION
# Pull Request

## 📖 Description

In Firefox, using the [range deleteContents()](https://developer.mozilla.org/en-US/docs/Web/API/Range/deleteContents) function does not work as expected when those contents are in the shadow root of an element. As a result, the `disposeContiguousBatch` that relies on `deleteContents` sometimes deletes the incorrect range of nodes. Specifically, when trying to delete a range of nodes that are in the light dom, an extra node in the shadow root can be deleted. This can cause a multitude of problems since a seemingly arbitrary node gets "randomly" deleted while interacting with a component. 

### 🎫 Issues

Nimble issue: https://github.com/ni/nimble/issues/2744
Additional context/explanation: https://github.com/ni/fast/pull/39#discussion_r3067112128
Original FAST PR where the optimization was first introduced: https://github.com/microsoft/fast/pull/2806

## 👩‍💻 Reviewer Notes

I tested these changes within the [nimble](https://github.com/ni/nimble) repository, focusing on the `nimble-table` and `nimble-rich-text-editor`. Both components worked as expected in Firefox, even without the previously submitted workaround to the table.

I also looked at how `disposeContiguousBatch` was called within the table when rows were sorted, groups expanded/collapsed, and context menus opened/closed, particularly with tables populated with large numbers of rows. Based on my evaluation, I don't think `disposeContiguousBatch` is ever called with all the rows of the table or even all the visible rows in the table (i.e. I never saw it called with more than 3 views), so I do not think that changing the implementation of `disposeContiguousBatch` will have a negative performance impact on the `nimble-table`.

## 📑 Test Plan

I've addition a few tests to this repository.

I also manually verified that within nimble, the issues described in https://github.com/ni/nimble/issues/2744 are no longer a reproducible, even without the workaround previously submitted for the nimble table.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

None in this repository