### PR TITLE
chore: add SCA scanning configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,4 @@
 /change
 
 /.snyk @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
+/.wiz @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,5 +13,5 @@
 # Change files don't need explicit reviewers
 /change
 
-/.snyk @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
-/.wiz @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
+/.snyk @ni/security-scanning-owners
+/.wiz @ni/security-scanning-owners

--- a/.wiz
+++ b/.wiz
@@ -1,2 +1,9 @@
+# Wiz Code global path exclusions for this repository.
+#
+# NOTE: Both /* and /**/* patterns are required per directory due to a known
+# Wiz glob bug (WZ-81029) where /**/* does not match direct children of a
+# directory. The /* pattern catches direct children while /**/* catches nested
+# files. This duplication can be removed once the bug is fixed.
+
 ignore:
   global_paths: {}

--- a/.wiz
+++ b/.wiz
@@ -1,0 +1,2 @@
+ignore:
+  global_paths: {}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ If a beachball publish command fails on the pipeline so packages are partially p
 
 ### Security scanning
 
-See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
+**Contributors within NI/Emerson**: See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
 
 **Contributors outside of NI/Emerson**: If you are having issues resolving a vulnerability identified on your PR, consult with a code owner to understand your options for resolution.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,17 +40,11 @@ If a beachball publish command fails on the pipeline so packages are partially p
 3. Commit the changes from `npm run sync` and run `npm run change` for those changes.
 4. Submit a PR for the branch and merge.
 
-### Security scanning with Snyk
+### Security scanning
 
-This repository uses [Snyk](https://snyk.io/) for security scanning to identify and fix vulnerabilities in code before they reach production. Snyk provides Static Application Security Testing (SAST) that scans your code for security issues as you develop.
+See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
 
-- **IDE integration**: Install the Snyk extension for [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=snyk-security.snyk-vulnerability-scanner) or [Visual Studio](https://marketplace.visualstudio.com/items?itemName=snyk-security.snyk-vulnerability-scanner-vs-2022) to get real-time security feedback while writing code. To suggest the Snyk extension to contributors, add `.vscode/extensions.json` or `.vsconfig` files to your project root. The VSCode Snyk extension has a richer feature set and is the preferred IDE for working with Snyk.
-- **Pull request scanning**: Snyk automatically scans PRs and posts comments for high/critical vulnerabilities.
-- **Post-merge monitoring**: Automated bugs are created for unresolved issues after code is merged.
-
-**Contributors within NI/Emerson**: For detailed guidance on working with Snyk, including how to address security issues and create ignore records, see the [Snyk reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/146862/Snyk-reference).
-
-**Contributors outside of NI/Emerson**: If you are having issues resolving a vulnerability Snyk identifies on your PR, consult with a code owner to understand your options for resolution.
+**Contributors outside of NI/Emerson**: If you are having issues resolving a vulnerability identified on your PR, consult with a code owner to understand your options for resolution.
 
 ## Handling intermittent test failures
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

- Add .wiz config file
- Created a team for the security scanning files
- Replaced security scanning section in the readme with a link to the handbook document, which already has the wiz content. The readme content was duplicated across multiple repos, we will have more updates, and the handbook provides a central location for those updates.


### 🎫 Issues

[US 3813726: Update repo-level files for SCA awareness](https://dev.azure.com/ni/DevCentral/_workitems/edit/3813726) / [Task 3926774: ni-kismet/helium-db-mongo](https://dev.azure.com/ni/DevCentral/_workitems/edit/3926774)

## 👩‍💻 Reviewer Notes

Just wiz config + doc update

## 📑 Test Plan

PR

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.