### PR TITLE
Fix tooltip's delay attribute binding to return number

### DIFF
--- a/change/@ni-fast-foundation-01b16194-38a5-4db4-89c5-532c14b3854b.json
+++ b/change/@ni-fast-foundation-01b16194-38a5-4db4-89c5-532c14b3854b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix tooltip's delay attribute binding to return number",
+  "packageName": "@ni/fast-foundation",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -1,4 +1,4 @@
-import { attr, DOM, FASTElement, observable } from "@ni/fast-element";
+import { attr, DOM, FASTElement, nullableNumberConverter, observable } from "@ni/fast-element";
 import { Direction, keyEscape } from "@ni/fast-web-utilities";
 import type {
     AnchoredRegion,
@@ -61,7 +61,7 @@ export class Tooltip extends FoundationElement {
      * @public
      * HTML Attribute: delay
      */
-    @attr
+    @attr({ converter: nullableNumberConverter })
     public delay: number = 300;
 
     /**


### PR DESCRIPTION
# Pull Request

## 📖 Description

The tooltip's `delay` attribute was missing a `nullableNumberConverter`, which would prevent it from binding properly as a number value.

### 🎫 Issues

This is the issue in the Microsoft version of this repo (which is long since fixed):
https://github.com/microsoft/fast/issues/6257