### PR TITLE
Remove Snyk configuration (.snyk)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,5 +13,4 @@
 # Change files don't need explicit reviewers
 /change
 
-/.snyk @ni/security-scanning-owners
 /.wiz @ni/security-scanning-owners

--- a/.snyk
+++ b/.snyk
@@ -1,7 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-exclude:
-  global:
-    - '**/node_modules/**'
-version: v1.25.1
-ignore: {}
-patch: {}


### PR DESCRIPTION
Removes the `.snyk` configuration file as part of the Snyk -> Wiz migration.

Snyk scanning has been replaced by Wiz, so the repo-level `.snyk` policy /
ignore file is no longer used.

Work item: AB#3893372